### PR TITLE
allow reserving machines upto 24 hours.

### DIFF
--- a/softserve/templates/form.html
+++ b/softserve/templates/form.html
@@ -29,6 +29,7 @@
         <option value="2">2</option>
         <option value="3">3</option>
         <option value="4">4</option>
+        <option value="24">5</option>
       </select>
     </div>
   </div>

--- a/softserve/views.py
+++ b/softserve/views.py
@@ -87,7 +87,7 @@ def get_node_data():
         pubkey_ = request.form['pubkey']
 
         # Validating the hours and node counts
-        if int(counts) > 5 or int(hours_) > 4 or int(counts) > n:
+        if int(counts) > 5 or int(hours_) > 24 or int(counts) > n:
             flash('Please enter the valid data')
             logging.exception('User entered the invalid hours or counts value')
             return render_template('form.html', n=n)


### PR DESCRIPTION
Installing dependencies via ansible and compiling and installing gluster
after that on the soft serve VMs takes 30 minutes at best. The remaining
3.5 hours might not be enough for non-rockstar programmers like myself
to debug issues. Hence providing a 24 hour option to reserve machines
until https://github.com/gluster/softserve/issues/31 gets addressed.

Signed-off-by: Ravishankar N <ravishankar@redhat.com>