### PR TITLE
Fix error in inventory file

### DIFF
--- a/playbooks/inventory
+++ b/playbooks/inventory
@@ -3,4 +3,3 @@
 
 [softserve:vars]
 location=aws
-ansible_ssh_common_args='-o ProxyCommand="ssh -q -W %h:%p root@logs.aws.gluster.org"'


### PR DESCRIPTION
Removed the line:
ansible_ssh_common_args='-o ProxyCommand="ssh -q -W %h:%p root@logs.aws.gluster.org"'
from the inventory as it is erraneous.

Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>