### PR TITLE
Update gluster repo URL

### DIFF
--- a/playbooks/regressions-final.yml
+++ b/playbooks/regressions-final.yml
@@ -126,7 +126,7 @@
 
   - name: Clone the glusterfs code
     git:
-      repo: 'git://review.gluster.org/glusterfs'
+      repo: 'git://github.com/gluster/glusterfs'
       dest: '/home/centos/glusterfs'
       version: HEAD
       update: yes


### PR DESCRIPTION
...to point to the one on github instead of the old gerrit URL.

Signed-off-by: Ravishankar N <ravishankar@redhat.com>